### PR TITLE
Switch from inherited method to callback

### DIFF
--- a/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/ModelRecordTest.java
+++ b/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/ModelRecordTest.java
@@ -7,6 +7,7 @@ import com.fanpics.opensource.android.modelrecord.callback.DeleteCallback;
 import com.fanpics.opensource.android.modelrecord.callback.LoadCallback;
 import com.fanpics.opensource.android.modelrecord.callback.LoadListCallback;
 import com.fanpics.opensource.android.modelrecord.callback.UpdateCallback;
+import com.fanpics.opensource.android.modelrecord.event.FailureEvent;
 import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
 import com.fanpics.opensource.android.modelrecord.settings.MultiRecordSettings;
 import com.fanpics.opensource.android.modelrecord.settings.SingleRecordSettings;
@@ -15,7 +16,6 @@ import com.squareup.otto.Bus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
 
@@ -58,13 +58,13 @@ public class ModelRecordTest {
     private void setupSettings(SingleRecordSettings settings) {
         when(settings.getCache()).thenReturn(cache);
         when(settings.getSuccessEvent()).thenReturn(mock(SuccessEvent.class));
-        when(settings.getFailureEvent()).thenReturn(mock(Object.class));
+        when(settings.getFailureEvent()).thenReturn(mock(FailureEvent.class));
     }
 
     private void setupSettings(MultiRecordSettings settings) {
         when(settings.getCache()).thenReturn(cache);
         when(settings.getSuccessEvent()).thenReturn(mock(SuccessEvent.class));
-        when(settings.getFailureEvent()).thenReturn(mock(Object.class));
+        when(settings.getFailureEvent()).thenReturn(mock(FailureEvent.class));
     }
 
     @Test
@@ -82,7 +82,7 @@ public class ModelRecordTest {
 
         assertThat(singleRecordSettings.getSuccessEvent().hasFinished());
         verify(modelRecord).setupLoadSettings(any(SingleRecordSettings.class), eq(object));
-        verify(modelRecord).loadOnServerAsynchronously(eq(object), any(LoadCallback.class));
+        verify(singleRecordSettings).callOnServerAsync(eq(object), any(LoadCallback.class));
         verify(cache, never()).load(eq(object));
     }
 
@@ -106,7 +106,7 @@ public class ModelRecordTest {
         assertThat(singleRecordSettings.getSuccessEvent().hasFinished());
         verify(cache).load(object);
         verify(modelRecord.bus).post(singleRecordSettings.getSuccessEvent());
-        verify(modelRecord).loadOnServerAsynchronously(eq(object), any(LoadCallback.class));
+        verify(singleRecordSettings).callOnServerAsync(eq(object), any(LoadCallback.class));
     }
 
     @Test
@@ -129,7 +129,7 @@ public class ModelRecordTest {
         assertThat(singleRecordSettings.getSuccessEvent().hasFinished());
         verify(cache).load(object);
         verify(modelRecord.bus).post(singleRecordSettings.getSuccessEvent());
-        verify(modelRecord, never()).loadOnServerAsynchronously(eq(object), any(LoadCallback.class));
+        verify(singleRecordSettings, never()).callOnServerAsync(eq(object), any(LoadCallback.class));
     }
 
     @Test
@@ -145,7 +145,7 @@ public class ModelRecordTest {
         modelRecord.loadList(object, new MultiRecordSettings(MultiRecordSettings.Type.LOAD));
 
         verify(modelRecord).setupLoadListSettings(any(MultiRecordSettings.class), any(Object.class));
-        verify(modelRecord).loadListOnServerAsynchronously(eq(object), any(LoadListCallback.class));
+        verify(multiRecordSettings).callOnServerAsync(eq(object), any(LoadListCallback.class));
         verify(cache, never()).loadList(eq(object));
     }
 
@@ -167,13 +167,13 @@ public class ModelRecordTest {
 
         verify(cache).loadList(object);
         verify(modelRecord.bus).post(multiRecordSettings.getSuccessEvent());
-        verify(modelRecord).loadListOnServerAsynchronously(eq(object), any(LoadListCallback.class));
+        verify(multiRecordSettings).callOnServerAsync(eq(object), any(LoadListCallback.class));
     }
 
     @Test
     public void testLoadingListWithCacheAndNoNetwork() {
         final Object object = new Object();
-        final List<Object> result = new ArrayList<Object>();
+        final List<Object> result = new ArrayList<>();
 
         when(modelRecord.setupLoadListSettings(any(MultiRecordSettings.class), any(Object.class))).thenReturn(multiRecordSettings);
         when(cache.loadList(object)).thenReturn(result);
@@ -188,7 +188,7 @@ public class ModelRecordTest {
 
         verify(cache).loadList(object);
         verify(modelRecord.bus).post(multiRecordSettings.getSuccessEvent());
-        verify(modelRecord, never()).loadListOnServerAsynchronously(eq(object), any(LoadListCallback.class));
+        verify(multiRecordSettings, never()).callOnServerAsync(eq(object), any(LoadListCallback.class));
     }
 
     @Test
@@ -247,30 +247,33 @@ public class ModelRecordTest {
     public void testCreate() {
         final Object object = new Object();
         doCallRealMethod().when(modelRecord).create(object);
+        when(modelRecord.setupCreateSettings(any(SingleRecordSettings.class), eq(object))).thenReturn(singleRecordSettings);
         modelRecord.create(object);
 
         verify(modelRecord).setupCreateSettings(any(SingleRecordSettings.class), eq(object));
-        verify(modelRecord).createOnServer(eq(object), any(CreateCallback.class));
+        verify(singleRecordSettings).callOnServerAsync(eq(object), any(CreateCallback.class));
     }
 
     @Test
     public void testDelete() {
         final Object object = new Object();
+        when(modelRecord.setupDeleteSettings(any(SingleRecordSettings.class), eq(object))).thenReturn(singleRecordSettings);
         doCallRealMethod().when(modelRecord).delete(object);
         modelRecord.delete(object);
 
         verify(modelRecord).setupDeleteSettings(any(SingleRecordSettings.class), eq(object));
-        verify(modelRecord).deleteOnServer(eq(object), any(DeleteCallback.class));
+        verify(singleRecordSettings).callOnServerAsync(eq(object), any(DeleteCallback.class));
     }
 
     @Test
     public void testUpdate() {
         final Object object = new Object();
+        when(modelRecord.setupUpdateSettings(any(SingleRecordSettings.class), eq(object))).thenReturn(singleRecordSettings);
         doCallRealMethod().when(modelRecord).update(object);
         modelRecord.update(object);
 
         verify(modelRecord).setupUpdateSettings(any(SingleRecordSettings.class), eq(object));
-        verify(modelRecord).updateOnServer(eq(object), any(UpdateCallback.class));
+        verify(singleRecordSettings).callOnServerAsync(eq(object), any(UpdateCallback.class));
     }
 
 }

--- a/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/callback/RecordCallbackTest.java
+++ b/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/callback/RecordCallbackTest.java
@@ -1,14 +1,13 @@
 package com.fanpics.opensource.android.modelrecord.callback;
 
 import com.fanpics.opensource.android.modelrecord.RecordCache;
+import com.fanpics.opensource.android.modelrecord.event.FailureEvent;
 import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
 import com.fanpics.opensource.android.modelrecord.settings.SingleRecordSettings;
 import com.squareup.otto.Bus;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import retrofit.RetrofitError;
 
@@ -98,7 +97,7 @@ public class RecordCallbackTest {
 
     @Test
     public void testFailure() {
-        final Object event = new Object();
+        final FailureEvent event = mock(FailureEvent.class);
 
         when(recordCallback.settings.getFailureEvent()).thenReturn(event);
         doCallRealMethod().when(recordCallback).postFailure(any(RetrofitError.class));

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/ModelRecord.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/ModelRecord.java
@@ -43,11 +43,7 @@ public class ModelRecord<T> {
     public void create(T model){
         SingleRecordSettings settings = setupCreateSettings(new SingleRecordSettings<T>(), model);
         final CreateCallback createCallback = CreateCallback.createFromSettings(settings, bus, httpReport);
-        createOnServer(model, createCallback);
-    }
-
-    protected void createOnServer(T model, CreateCallback createCallback) {
-        throw new RuntimeException("createOnServer() must be implemented before calling create");
+        settings.callOnServerAsync(model, createCallback);
     }
 
     protected SingleRecordSettings setupCreateSettings(SingleRecordSettings recordCallbackSettings, T model) {
@@ -57,11 +53,7 @@ public class ModelRecord<T> {
     public void update(T model){
         SingleRecordSettings settings = setupUpdateSettings(new SingleRecordSettings<T>(), model);
         final UpdateCallback updateCallback = UpdateCallback.createFromSettings(settings, bus, httpReport);
-        updateOnServer(model, updateCallback);
-    }
-
-    protected void updateOnServer(T model, UpdateCallback updateCallback) {
-        throw new RuntimeException("updateOnServer() must be implemented before calling update");
+        settings.callOnServerAsync(model, updateCallback);
     }
 
     protected SingleRecordSettings setupUpdateSettings(SingleRecordSettings recordCallbackSettings, T model) {
@@ -130,7 +122,7 @@ public class ModelRecord<T> {
     private List loadListOnServer(Object key, MultiRecordSettings settings) {
         final LoadListCallback loadListCallback = LoadListCallback.createFromSettings(settings, bus, httpReport, handler);
         if (settings.shouldRunSynchronously()){
-            final Result<List> result = loadListOnServerSynchronously(key);
+            final Result<List> result = settings.callOnServerSynchronously(key);
             if(!result.shouldCache()) {
                 loadListCallback.disableCaching();
             }
@@ -138,17 +130,9 @@ public class ModelRecord<T> {
             loadListCallback.synchronousSuccess(result.getModel(), result.getResponse());
             return result.getModel();
         } else {
-            loadListOnServerAsynchronously(key, loadListCallback);
+            settings.callOnServerAsync(key, loadListCallback);
             return null;
         }
-    }
-
-    protected void loadListOnServerAsynchronously(Object key, LoadListCallback loadListCallback) {
-        throw new RuntimeException("loadListOnServerAsynchronously() must be implemented before calling loadList with settings set to asynchronous");
-    }
-
-    protected Result<List> loadListOnServerSynchronously(Object key) {
-        throw new RuntimeException("loadListOnServerSynchronously() must be implemented before calling loadList with settings set to synchronous");
     }
 
     protected MultiRecordSettings setupLoadListSettings(MultiRecordSettings recordCallbackSettings, Object key) {
@@ -213,7 +197,7 @@ public class ModelRecord<T> {
     private Object loadOnServer(Object key, SingleRecordSettings settings) {
         final LoadCallback loadCallback = LoadCallback.createFromSettings(settings, bus, httpReport, key, handler);
         if (settings.shouldRunSynchronously()){
-            final Result result = loadOnServerSynchronously(key);
+            final Result result = settings.callOnServerSynchronously(key);
             if(!result.shouldCache()) {
                 loadCallback.disableCaching();
             }
@@ -221,7 +205,7 @@ public class ModelRecord<T> {
             loadCallback.synchronousSuccess(result.getModel(), result.getResponse());
             return result.getModel();
         } else {
-            loadOnServerAsynchronously(key, loadCallback);
+            settings.callOnServerAsync(key, loadCallback);
             return null;
         }
     }
@@ -238,14 +222,6 @@ public class ModelRecord<T> {
         }
     }
 
-    protected void loadOnServerAsynchronously(Object key, LoadCallback callback) {
-        throw new RuntimeException("loadOnServerAsynchronously() must be implemented before calling load with settings set to asynchronous");
-    }
-
-    protected Result loadOnServerSynchronously(Object key) {
-        throw new RuntimeException("loadOnServerAsynchronously() must be implemented before calling load with settings set to synchronous");
-    }
-
     protected SingleRecordSettings setupLoadSettings(SingleRecordSettings recordCallbackSettings, Object key) {
         throw new RuntimeException("setupLoadSettings() must be implemented before calling load");
     }
@@ -253,11 +229,7 @@ public class ModelRecord<T> {
     public void delete(T model){
         SingleRecordSettings settings = setupDeleteSettings(new SingleRecordSettings(), model);
         final DeleteCallback deleteCallback = DeleteCallback.createFromSettings(settings, bus, httpReport);
-        deleteOnServer(model, deleteCallback);
-    }
-
-    protected void deleteOnServer(T model, DeleteCallback deleteCallback) {
-        throw new RuntimeException("deleteOnServer() must be implemented before calling delete");
+        settings.callOnServerAsync(model, deleteCallback);
     }
 
     protected SingleRecordSettings setupDeleteSettings(SingleRecordSettings recordCallbackSettings, T model) {

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/settings/BaseRecordSettings.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/settings/BaseRecordSettings.java
@@ -1,5 +1,6 @@
 package com.fanpics.opensource.android.modelrecord.settings;
 
+import com.fanpics.opensource.android.modelrecord.Result;
 import com.fanpics.opensource.android.modelrecord.callback.FailureCallback;
 import com.fanpics.opensource.android.modelrecord.callback.SuccessCallback;
 import com.fanpics.opensource.android.modelrecord.event.FailureEvent;
@@ -7,21 +8,26 @@ import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
 
 import java.util.Date;
 
+import retrofit.Callback;
+
 public abstract class BaseRecordSettings<T> {
+    private AsyncServerCall asyncServerCall;
+    private SynchronousServerCall synchronousServerCall;
+
     public static enum Type {REFRESH, CACHE_ONLY, NETWORK_AS_FALLBACK, LOAD;}
 
     private SuccessEvent<T> successEvent;
     private boolean runSynchronously;
+
     private SuccessCallback<T> successCallback;
 
     private FailureEvent failureEvent;
     private FailureCallback failureCallback;
     private final Date createdTime = new Date();
-    private Type type;
 
+    private Type type;
     public BaseRecordSettings() {
     }
-
     public BaseRecordSettings(Type type) {
         this.type = type;
     }
@@ -100,8 +106,39 @@ public abstract class BaseRecordSettings<T> {
         runSynchronously = true;
     }
 
+    public void callOnServerAsync(Object key, Callback callback) {
+        if (asyncServerCall == null) {
+            throw new RuntimeException("AsyncServerCall must be set with setAsyncServerCall(call) before performing an async action");
+        }
+
+        asyncServerCall.call(key, callback);
+    }
+
+    public Result callOnServerSynchronously(Object key) {
+        if (synchronousServerCall == null) {
+            throw new RuntimeException("SynchronousServerCall must be set with setSynchronousServerCall(call) before performing an async action");
+        }
+
+        return synchronousServerCall.call(key);
+    }
+
+    public void setAsyncServerCall(AsyncServerCall asyncServerCall) {
+        this.asyncServerCall = asyncServerCall;
+    }
+
+    public void setSynchronousServerCall(SynchronousServerCall synchronousServerCall) {
+        this.synchronousServerCall = synchronousServerCall;
+    }
+
     public abstract void removeCache();
 
     protected abstract boolean hasCache();
 
+    public interface AsyncServerCall {
+        void call(Object key, Callback callback);
+    }
+
+    private interface SynchronousServerCall {
+        Result call(Object key);
+    }
 }

--- a/sample-app/src/main/AndroidManifest.xml
+++ b/sample-app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.fanpics.opensource.android.modelrecord.sample" >
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"

--- a/sample-app/src/main/java/com/fanpics/opensource/android/modelrecord/sample/ui/activity/MainActivity.java
+++ b/sample-app/src/main/java/com/fanpics/opensource/android/modelrecord/sample/ui/activity/MainActivity.java
@@ -1,7 +1,8 @@
 package com.fanpics.opensource.android.modelrecord.sample.ui.activity;
 
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -10,12 +11,12 @@ import android.widget.Toast;
 
 import com.fanpics.opensource.android.modelrecord.sample.R;
 import com.fanpics.opensource.android.modelrecord.sample.data.model.ImgurItem;
+import com.fanpics.opensource.android.modelrecord.sample.data.model.record.ImgurDataRecord;
 import com.fanpics.opensource.android.modelrecord.sample.event.ImgurDataLoadFailedEvent;
 import com.fanpics.opensource.android.modelrecord.sample.event.ImgurDataLoadSucceededEvent;
 import com.fanpics.opensource.android.modelrecord.sample.ui.adapter.ImgurAdapter;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
-import com.fanpics.opensource.android.modelrecord.sample.data.model.record.ImgurDataRecord;
 
 import java.util.List;
 
@@ -110,6 +111,8 @@ public class MainActivity extends ActionBarActivity {
     public void onListLoadFailed(ImgurDataLoadFailedEvent event) {
         isLoading = false;
         stopReloadAnimation();
+        Log.e("List load failed", "exception", event.getError());
+//        throw new RuntimeException(event.getError());
 
         displayLoadFailedToast();
     }


### PR DESCRIPTION
Instead of forcing the user to inherit 2-3 methods for every action they
wish to perform, instead use a single configuration method and behavior
via callbacks.
