### PR TITLE
Remove direct calls to event bus

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'robolectric'
 ext {
     PUBLISH_GROUP_ID = 'com.fanpics.opensource'
     PUBLISH_ARTIFACT_ID = 'model-record'
-    PUBLISH_VERSION = '1.0.0'
+    PUBLISH_VERSION = '1.1.0'
 }
 
 android {
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 21
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1.0"
     }
     buildTypes {
         release {

--- a/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/ModelRecordTest.java
+++ b/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/ModelRecordTest.java
@@ -9,9 +9,9 @@ import com.fanpics.opensource.android.modelrecord.callback.LoadListCallback;
 import com.fanpics.opensource.android.modelrecord.callback.UpdateCallback;
 import com.fanpics.opensource.android.modelrecord.configuration.MultiRecordConfiguration;
 import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
 import com.fanpics.opensource.android.modelrecord.event.FailureEvent;
 import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
-import com.squareup.otto.Bus;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -143,7 +143,7 @@ public class ModelRecordTest {
         when(modelRecord.setupLoadConfiguration(any(SingleRecordConfiguration.class), any(Object.class))).thenReturn(singleRecordConfiguration);
         when(singleRecordConfiguration.getCache()).thenReturn(cache);
         when(cache.load(object)).thenReturn(result);
-        modelRecord.bus = mock(Bus.class);
+        modelRecord.eventProcessor = mock(EventProcessor.class);
 
         when(singleRecordConfiguration.shouldLoadFromNetwork()).thenReturn(true);
         when(singleRecordConfiguration.shouldLoadFromCache()).thenReturn(true);
@@ -154,7 +154,7 @@ public class ModelRecordTest {
 
         assertThat(singleRecordConfiguration.getSuccessEvent().hasFinished());
         verify(cache).load(object);
-        verify(modelRecord.bus).post(singleRecordConfiguration.getSuccessEvent());
+        verify(modelRecord.eventProcessor).process(singleRecordConfiguration.getSuccessEvent());
         verify(singleRecordConfiguration).performAsynchronousNetworkCall(eq(object), any(LoadCallback.class));
     }
 
@@ -166,7 +166,7 @@ public class ModelRecordTest {
         when(modelRecord.setupLoadConfiguration(any(SingleRecordConfiguration.class), any(Object.class))).thenReturn(singleRecordConfiguration);
         when(singleRecordConfiguration.getCache()).thenReturn(cache);
         when(cache.load(object)).thenReturn(result);
-        modelRecord.bus = mock(Bus.class);
+        modelRecord.eventProcessor = mock(EventProcessor.class);
 
         when(singleRecordConfiguration.shouldLoadFromNetwork()).thenReturn(false);
         when(singleRecordConfiguration.shouldLoadFromCache()).thenReturn(true);
@@ -177,7 +177,7 @@ public class ModelRecordTest {
 
         assertThat(singleRecordConfiguration.getSuccessEvent().hasFinished());
         verify(cache).load(object);
-        verify(modelRecord.bus).post(singleRecordConfiguration.getSuccessEvent());
+        verify(modelRecord.eventProcessor).process(singleRecordConfiguration.getSuccessEvent());
         verify(singleRecordConfiguration, never()).performAsynchronousNetworkCall(eq(object), any(LoadCallback.class));
     }
 
@@ -214,7 +214,7 @@ public class ModelRecordTest {
 
         when(modelRecord.setupLoadListConfiguration(any(MultiRecordConfiguration.class), any(Object.class))).thenReturn(multiRecordConfiguration);
         when(cache.loadList(object)).thenReturn(result);
-        modelRecord.bus = mock(Bus.class);
+        modelRecord.eventProcessor = mock(EventProcessor.class);
 
         when(multiRecordConfiguration.shouldLoadFromNetwork()).thenReturn(true);
         when(multiRecordConfiguration.shouldLoadFromCache()).thenReturn(true);
@@ -224,7 +224,7 @@ public class ModelRecordTest {
         modelRecord.loadList(object, new MultiRecordConfiguration(MultiRecordConfiguration.Type.LOAD));
 
         verify(cache).loadList(object);
-        verify(modelRecord.bus).post(multiRecordConfiguration.getSuccessEvent());
+        verify(modelRecord.eventProcessor).process(multiRecordConfiguration.getSuccessEvent());
         verify(multiRecordConfiguration).performAsynchronousNetworkCall(eq(object), any(LoadListCallback.class));
     }
 
@@ -235,7 +235,7 @@ public class ModelRecordTest {
 
         when(modelRecord.setupLoadListConfiguration(any(MultiRecordConfiguration.class), any(Object.class))).thenReturn(multiRecordConfiguration);
         when(cache.loadList(object)).thenReturn(result);
-        modelRecord.bus = mock(Bus.class);
+        modelRecord.eventProcessor = mock(EventProcessor.class);
 
         when(multiRecordConfiguration.shouldLoadFromNetwork()).thenReturn(false);
         when(multiRecordConfiguration.shouldLoadFromCache()).thenReturn(true);
@@ -245,7 +245,7 @@ public class ModelRecordTest {
         modelRecord.loadList(object, new MultiRecordConfiguration(MultiRecordConfiguration.Type.LOAD));
 
         verify(cache).loadList(object);
-        verify(modelRecord.bus).post(multiRecordConfiguration.getSuccessEvent());
+        verify(modelRecord.eventProcessor).process(multiRecordConfiguration.getSuccessEvent());
         verify(multiRecordConfiguration, never()).performAsynchronousNetworkCall(eq(object), any(LoadListCallback.class));
     }
 

--- a/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/callback/DeleteCallbackTest.java
+++ b/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/callback/DeleteCallbackTest.java
@@ -1,10 +1,10 @@
 package com.fanpics.opensource.android.modelrecord.callback;
 
 import com.fanpics.opensource.android.modelrecord.RecordCache;
+import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
 import com.fanpics.opensource.android.modelrecord.event.FailureEvent;
 import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
-import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
-import com.squareup.otto.Bus;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -18,12 +18,12 @@ public class DeleteCallbackTest {
 
     private RecordCache cache;
     private SingleRecordConfiguration configuration;
-    private Bus bus;
+    private EventProcessor eventProcessor;
 
     @Before
     public void createRecordCallback() {
         configuration = mock(SingleRecordConfiguration.class);
-        bus = mock(Bus.class);
+        eventProcessor = mock(EventProcessor.class);
         cache = mock(RecordCache.class);
     }
 
@@ -31,7 +31,7 @@ public class DeleteCallbackTest {
     @SuppressWarnings("unchecked")
     public void testFailureWithoutCache() {
         final Object model = new Object();
-        DeleteCallback<Object> deleteCallback = DeleteCallback.createFromConfiguration(configuration, bus, null, model);
+        DeleteCallback<Object> deleteCallback = DeleteCallback.createFromConfiguration(configuration, eventProcessor, null, model);
         when(configuration.getFailureEvent()).thenReturn(new FailureEvent());
         when(deleteCallback.configuration.getCache()).thenReturn(null);
 
@@ -44,7 +44,7 @@ public class DeleteCallbackTest {
     @SuppressWarnings("unchecked")
     public void testSuccessWithCache() {
         final Object model = new Object();
-        DeleteCallback<Object> deleteCallback = DeleteCallback.createFromConfiguration(configuration, bus, null, model);
+        DeleteCallback<Object> deleteCallback = DeleteCallback.createFromConfiguration(configuration, eventProcessor, null, model);
         when(configuration.getSuccessEvent()).thenReturn(new SuccessEvent());
         when(deleteCallback.configuration.getCache()).thenReturn(cache);
 

--- a/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/callback/RecordCallbackTest.java
+++ b/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/callback/RecordCallbackTest.java
@@ -1,10 +1,10 @@
 package com.fanpics.opensource.android.modelrecord.callback;
 
 import com.fanpics.opensource.android.modelrecord.RecordCache;
+import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
 import com.fanpics.opensource.android.modelrecord.event.FailureEvent;
 import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
-import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
-import com.squareup.otto.Bus;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +27,7 @@ public class RecordCallbackTest {
     public void createRecordCallback() {
         recordCallback = mock(RecordCallback.class);
         recordCallback.configuration = mock(SingleRecordConfiguration.class);
-        recordCallback.bus = mock(Bus.class);
+        recordCallback.eventProcessor = mock(EventProcessor.class);
         RecordCache cache = mock(RecordCache.class);
         when(recordCallback.getRecordConfiguration()).thenCallRealMethod();
         when(recordCallback.configuration.getCache()).thenReturn(cache);
@@ -46,7 +46,7 @@ public class RecordCallbackTest {
 
         recordCallback.success(object, null);
         verify(recordCallback.configuration).callSuccessCallback(object);
-        verify(recordCallback.bus).post(event);
+        verify(recordCallback.eventProcessor).process(event);
     }
 
     @Test
@@ -61,7 +61,7 @@ public class RecordCallbackTest {
 
         recordCallback.success(object, null);
         verify(recordCallback.configuration).callSuccessCallback(object);
-        verify(recordCallback.bus).post(event);
+        verify(recordCallback.eventProcessor).process(event);
         verify(recordCallback).runCacheThread(object);
     }
 
@@ -105,7 +105,7 @@ public class RecordCallbackTest {
 
         recordCallback.failure(mock(RetrofitError.class));
         verify(recordCallback.configuration).callFailureCallback();
-        verify(recordCallback.bus).post(event);
+        verify(recordCallback.eventProcessor).process(event);
     }
 
 }

--- a/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/event/OttoProcessorTest.java
+++ b/app/src/androidTest/java/com/fanpics/opensource/android/modelrecord/event/OttoProcessorTest.java
@@ -1,0 +1,30 @@
+package com.fanpics.opensource.android.modelrecord.event;
+
+import com.squareup.otto.Bus;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class OttoProcessorTest {
+
+    private OttoProcessor ottoProcessor;
+    private Bus bus;
+
+    @Before
+    public void setupEvent() {
+        bus = mock(Bus.class);
+        ottoProcessor = new OttoProcessor(bus);
+    }
+
+    @Test
+    public void processPostsToBus() {
+        final Object object = new Object();
+        ottoProcessor.process(object);
+
+        verify(bus).post(object);
+    }
+
+}

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/BaseRecordCallback.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/BaseRecordCallback.java
@@ -3,10 +3,10 @@ package com.fanpics.opensource.android.modelrecord.callback;
 import android.os.Handler;
 
 import com.fanpics.opensource.android.modelrecord.HttpReport;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
 import com.fanpics.opensource.android.modelrecord.event.FailureEvent;
 import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
 import com.fanpics.opensource.android.modelrecord.configuration.BaseRecordConfiguration;
-import com.squareup.otto.Bus;
 
 import java.util.Date;
 
@@ -16,16 +16,16 @@ import retrofit.client.Response;
 public abstract class BaseRecordCallback {
 
     private final HttpReport httpReport;
-    protected Bus bus;
+    protected EventProcessor eventProcessor;
     protected Handler handler;
 
-    protected BaseRecordCallback(Bus bus, HttpReport httpReport){
-        this.bus = bus;
+    protected BaseRecordCallback(EventProcessor eventProcessor, HttpReport httpReport){
+        this.eventProcessor = eventProcessor;
         this.httpReport = httpReport;
     }
 
-    public BaseRecordCallback(Bus bus, HttpReport httpReport, Handler handler) {
-        this.bus = bus;
+    public BaseRecordCallback(EventProcessor eventProcessor, HttpReport httpReport, Handler handler) {
+        this.eventProcessor = eventProcessor;
         this.httpReport = httpReport;
         this.handler = handler;
     }
@@ -44,7 +44,7 @@ public abstract class BaseRecordCallback {
         return new Runnable() {
             @Override
             public void run() {
-                bus.post(event);
+                eventProcessor.process(event);
             }
         };
     }
@@ -109,7 +109,7 @@ public abstract class BaseRecordCallback {
             public void run() {
                 final FailureEvent event = getRecordConfiguration().getFailureEvent();
                 event.setError(retrofitError);
-                bus.post(event);
+                eventProcessor.process(event);
             }
         };
     }

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/CreateCallback.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/CreateCallback.java
@@ -2,15 +2,15 @@ package com.fanpics.opensource.android.modelrecord.callback;
 
 import com.fanpics.opensource.android.modelrecord.HttpReport;
 import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
-import com.squareup.otto.Bus;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
 
 public class CreateCallback<T> extends RecordCallback<T> {
 
-    protected CreateCallback(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport) {
-        super(configuration, bus, httpReport);
+    protected CreateCallback(SingleRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport) {
+        super(configuration, eventProcessor, httpReport);
     }
 
-    public static <T> CreateCallback<T> createFromConfiguration(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport){
-        return new CreateCallback<>(configuration, bus, httpReport);
+    public static <T> CreateCallback<T> createFromConfiguration(SingleRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport){
+        return new CreateCallback<>(configuration, eventProcessor, httpReport);
     }
 }

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/DeleteCallback.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/DeleteCallback.java
@@ -3,18 +3,18 @@ package com.fanpics.opensource.android.modelrecord.callback;
 import com.fanpics.opensource.android.modelrecord.HttpReport;
 import com.fanpics.opensource.android.modelrecord.RecordCache;
 import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
-import com.squareup.otto.Bus;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
 
 public class DeleteCallback<T> extends RecordCallback<T> {
 
-    protected DeleteCallback(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport, T model) {
-        super(configuration, bus, httpReport);
+    protected DeleteCallback(SingleRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport, T model) {
+        super(configuration, eventProcessor, httpReport);
         setKey(model);
     }
 
-    public static <T> DeleteCallback<T> createFromConfiguration(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport,
+    public static <T> DeleteCallback<T> createFromConfiguration(SingleRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport,
                                                                 T model){
-        return new DeleteCallback<>(configuration, bus, httpReport, model);
+        return new DeleteCallback<>(configuration, eventProcessor, httpReport, model);
     }
 
     @SuppressWarnings("unchecked")

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/LoadCallback.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/LoadCallback.java
@@ -4,18 +4,18 @@ import android.os.Handler;
 
 import com.fanpics.opensource.android.modelrecord.HttpReport;
 import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
-import com.squareup.otto.Bus;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
 
 public class LoadCallback<T> extends RecordCallback<T> {
 
-    protected LoadCallback(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport, Object key, Handler handler) {
-        super(configuration, bus, httpReport, handler);
+    protected LoadCallback(SingleRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport, Object key, Handler handler) {
+        super(configuration, eventProcessor, httpReport, handler);
         setKey(key);
     }
 
-    public static <T> LoadCallback<T> createFromConfiguration(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport,
+    public static <T> LoadCallback<T> createFromConfiguration(SingleRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport,
                                                               Object key, Handler handler){
-        return new LoadCallback<>(configuration, bus, httpReport, key, handler);
+        return new LoadCallback<>(configuration, eventProcessor, httpReport, key, handler);
     }
 
 }

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/LoadListCallback.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/LoadListCallback.java
@@ -4,10 +4,10 @@ import android.os.Handler;
 
 import com.fanpics.opensource.android.modelrecord.HttpReport;
 import com.fanpics.opensource.android.modelrecord.RecordCache;
-import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
 import com.fanpics.opensource.android.modelrecord.configuration.BaseRecordConfiguration;
 import com.fanpics.opensource.android.modelrecord.configuration.MultiRecordConfiguration;
-import com.squareup.otto.Bus;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
+import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
 
 import java.util.List;
 
@@ -20,18 +20,18 @@ public class LoadListCallback<T> extends BaseRecordCallback implements Callback<
     protected MultiRecordConfiguration<T> configuration;
     protected Object key;
 
-    protected LoadListCallback(MultiRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport){
-        super(bus, httpReport);
+    protected LoadListCallback(MultiRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport){
+        super(eventProcessor, httpReport);
         this.configuration = configuration;
     }
 
-    protected LoadListCallback(MultiRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport, Handler handler) {
-        super(bus, httpReport, handler);
+    protected LoadListCallback(MultiRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport, Handler handler) {
+        super(eventProcessor, httpReport, handler);
         this.configuration = configuration;
     }
 
-    public static <T> LoadListCallback createFromConfiguration(MultiRecordConfiguration<T> settings, Bus bus, HttpReport httpReport, Handler handler) {
-        return new LoadListCallback<>(settings, bus, httpReport, handler);
+    public static <T> LoadListCallback createFromConfiguration(MultiRecordConfiguration<T> settings, EventProcessor eventProcessor, HttpReport httpReport, Handler handler) {
+        return new LoadListCallback<>(settings, eventProcessor, httpReport, handler);
     }
 
     public void setKey(Object key) {

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/RecordCallback.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/RecordCallback.java
@@ -4,10 +4,10 @@ import android.os.Handler;
 
 import com.fanpics.opensource.android.modelrecord.HttpReport;
 import com.fanpics.opensource.android.modelrecord.RecordCache;
-import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
 import com.fanpics.opensource.android.modelrecord.configuration.BaseRecordConfiguration;
 import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
-import com.squareup.otto.Bus;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
+import com.fanpics.opensource.android.modelrecord.event.SuccessEvent;
 
 import retrofit.Callback;
 import retrofit.RetrofitError;
@@ -18,12 +18,12 @@ public class RecordCallback<T> extends BaseRecordCallback implements Callback<T>
     protected SingleRecordConfiguration<T> configuration;
     protected Object key;
 
-    protected RecordCallback(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport){
-        super(bus, httpReport);
+    protected RecordCallback(SingleRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport){
+        super(eventProcessor, httpReport);
         this.configuration = configuration;
     }
 
-    public RecordCallback(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport, Handler handler) {
+    public RecordCallback(SingleRecordConfiguration<T> configuration, EventProcessor bus, HttpReport httpReport, Handler handler) {
         super(bus, httpReport, handler);
         this.configuration = configuration;
     }

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/UpdateCallback.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/callback/UpdateCallback.java
@@ -2,15 +2,15 @@ package com.fanpics.opensource.android.modelrecord.callback;
 
 import com.fanpics.opensource.android.modelrecord.HttpReport;
 import com.fanpics.opensource.android.modelrecord.configuration.SingleRecordConfiguration;
-import com.squareup.otto.Bus;
+import com.fanpics.opensource.android.modelrecord.event.EventProcessor;
 
 public class UpdateCallback<T> extends RecordCallback<T> {
 
-    protected UpdateCallback(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport) {
-        super(configuration, bus, httpReport);
+    protected UpdateCallback(SingleRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport) {
+        super(configuration, eventProcessor, httpReport);
     }
 
-    public static <T> UpdateCallback<T> createFromConfiguration(SingleRecordConfiguration<T> configuration, Bus bus, HttpReport httpReport){
-        return new UpdateCallback<>(configuration, bus, httpReport);
+    public static <T> UpdateCallback<T> createFromConfiguration(SingleRecordConfiguration<T> configuration, EventProcessor eventProcessor, HttpReport httpReport){
+        return new UpdateCallback<>(configuration, eventProcessor, httpReport);
     }
 }

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/event/EventProcessor.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/event/EventProcessor.java
@@ -1,0 +1,5 @@
+package com.fanpics.opensource.android.modelrecord.event;
+
+public abstract class EventProcessor {
+    public abstract void process(Object object);
+}

--- a/app/src/main/java/com/fanpics/opensource/android/modelrecord/event/OttoProcessor.java
+++ b/app/src/main/java/com/fanpics/opensource/android/modelrecord/event/OttoProcessor.java
@@ -1,0 +1,16 @@
+package com.fanpics.opensource.android.modelrecord.event;
+
+import com.squareup.otto.Bus;
+
+public class OttoProcessor extends EventProcessor {
+    private final Bus bus;
+
+    public OttoProcessor(Bus bus) {
+        this.bus = bus;
+    }
+
+    @Override
+    public void process(Object object) {
+        bus.post(object);
+    }
+}

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -27,7 +27,7 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile 'com.fanpics.opensource:model-record:1.0.0'
+    compile 'com.fanpics.opensource:model-record:1.1.0'
     compile 'com.squareup.picasso:picasso:2.3.2'
     compile 'io.realm:realm-android:0.75.1'
 


### PR DESCRIPTION
* Create generic EventProcessor class to allow users to user their own
event buses.
* Create OttoProcessor as a standard class to directly support event
buses
* Update to version 1.1.0